### PR TITLE
Dont try to delete session when failling to create it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,11 +193,13 @@ impl DriverSession {
             url: url.to_owned(),
         });
         let baseurl = try!(Url::parse(url).map_err(|_| Error::InvalidUrl));
-        let s = DriverSession {
+        let mut s = DriverSession {
             driver: driver,
             client: HttpClient::new(baseurl),
             session_id: session_id.to_owned(),
-            drop_session: true,
+            // This starts as false to avoid triggering the deletion call in Drop
+            // if an error occurs
+            drop_session: false,
         };
         info!("Connecting to session at {} with id {}", url, session_id);
 
@@ -209,6 +211,8 @@ impl DriverSession {
         let _ = s.get_current_url()?;
 
         info!("Connected to existing session {}", s.session_id);
+        // The session exists, enable session deletion on Drop
+        s.drop_session = true;
         Ok(s)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,13 +97,73 @@ impl Driver for HttpDriver {
     fn url(&self) -> &str { &self.url }
 }
 
+/// Wrapper around the hyper Client, that handles Json encoding and URL construction
+struct HttpClient {
+    baseurl: Url,
+    http: Client,
+}
+
+impl HttpClient {
+    pub fn new(baseurl: Url) -> Self {
+        HttpClient {
+            baseurl: baseurl,
+            http: Client::new(),
+        }
+    }
+
+    pub fn decode<D: DeserializeOwned + Debug>(res: &mut Response) -> Result<D, Error> {
+        let mut data = String::new();
+        try!(res.read_to_string(&mut data));
+        debug!("result status: {}\n\
+                body: '{}'", res.status, data);
+
+        if !res.status.is_success() {
+            let err: Value<WebDriverError> = try!(serde_json::from_str(&data));
+            trace!("deserialize error result: {:#?}", err);
+            return Err(Error::WebDriverError(err.value));
+        }
+        let response = serde_json::from_str(&data);
+        trace!("deserialize result: {:#?}", response);
+        Ok(response?)
+    }
+
+    pub fn get<D: DeserializeOwned + Debug>(&self, path: &str) -> Result<D, Error> {
+        let url = try!(self.baseurl.join(path)
+                           .map_err(|_| Error::InvalidUrl));
+        debug!("GET {}", url);
+        let mut res = try!(self.http.get(url)
+                            .send());
+        Self::decode(&mut res)
+    }
+
+    pub fn delete<D: DeserializeOwned + Debug>(&self, path: &str) -> Result<D, Error> {
+        let url = try!(self.baseurl.join(path)
+                           .map_err(|_| Error::InvalidUrl));
+        debug!("DELETE {}", url);
+        let mut res = try!(self.http.delete(url)
+                            .send());
+        Self::decode(&mut res)
+    }
+
+    pub fn post<D: DeserializeOwned + Debug, E: Serialize>(&self, path: &str, body: &E) -> Result<D, Error> {
+        let url = try!(self.baseurl.join(path)
+                           .map_err(|_| Error::InvalidUrl));
+        let body_str = try!(serde_json::to_string(body));
+        debug!("POST url: {}\n\
+                body: {}", url, body_str);
+        let mut res = try!(self.http.post(url)
+                            .body(&body_str)
+                            .send());
+        Self::decode(&mut res)
+    }
+}
+
 /// A WebDriver session.
 ///
 /// By default the session is removed on `Drop`
 pub struct DriverSession {
     driver: Box<Driver>,
-    baseurl: Url,
-    client: Client,
+    client: HttpClient,
     session_id: String,
     drop_session: bool,
 }
@@ -117,12 +177,11 @@ impl DriverSession {
                           .map_err(|_| Error::InvalidUrl)?;
         let mut s = DriverSession {
             driver: driver,
-            baseurl: baseurl,
-            client: Client::new(),
+            client: HttpClient::new(baseurl),
             session_id: String::new(),
             drop_session: true,
         };
-        info!("Creating session at {}", s.baseurl);
+        info!("Creating session at {}", s.client.baseurl);
         let sess = try!(s.new_session(&NewSessionCmd::new()));
         s.session_id = sess.sessionId;
         info!("Session {} created", s.session_id);
@@ -137,8 +196,7 @@ impl DriverSession {
         let baseurl = try!(Url::parse(url).map_err(|_| Error::InvalidUrl));
         let s = DriverSession {
             driver: driver,
-            baseurl: baseurl,
-            client: Client::new(),
+            client: HttpClient::new(baseurl),
             session_id: session_id.to_owned(),
             drop_session: true,
         };
@@ -164,130 +222,84 @@ impl DriverSession {
         self.drop_session = drop;
     }
 
-    fn get<D: DeserializeOwned + Debug>(&self, path: &str) -> Result<D, Error> {
-        let url = try!(self.baseurl.join(path)
-                           .map_err(|_| Error::InvalidUrl));
-        debug!("GET {}", url);
-        let mut res = try!(self.client.get(url)
-                            .send());
-        Self::decode(&mut res)
-    }
-
-    fn delete<D: DeserializeOwned + Debug>(&self, path: &str) -> Result<D, Error> {
-        let url = try!(self.baseurl.join(path)
-                           .map_err(|_| Error::InvalidUrl));
-        debug!("DELETE {}", url);
-        let mut res = try!(self.client.delete(url)
-                            .send());
-        Self::decode(&mut res)
-    }
-
-    fn decode<D: DeserializeOwned + Debug>(res: &mut Response) -> Result<D, Error> {
-        let mut data = String::new();
-        try!(res.read_to_string(&mut data));
-        debug!("result status: {}\n\
-                body: '{}'", res.status, data);
-
-        if !res.status.is_success() {
-            let err: Value<WebDriverError> = try!(serde_json::from_str(&data));
-            trace!("deserialize error result: {:#?}", err);
-            return Err(Error::WebDriverError(err.value));
-        }
-        let response = serde_json::from_str(&data);
-        trace!("deserialize result: {:#?}", response);
-        Ok(response?)
-    }
-
-    fn post<D: DeserializeOwned + Debug, E: Serialize>(&self, path: &str, body: &E) -> Result<D, Error> {
-        let url = try!(self.baseurl.join(path)
-                           .map_err(|_| Error::InvalidUrl));
-        let body_str = try!(serde_json::to_string(body));
-        debug!("POST url: {}\n\
-                body: {}", url, body_str);
-        let mut res = try!(self.client.post(url)
-                            .body(&body_str)
-                            .send());
-        Self::decode(&mut res)
-    }
-
     /// Create a new webdriver session
     fn new_session(&mut self, params: &NewSessionCmd) -> Result<Session, Error> {
-        let resp: Value<Session> = try!(self.post("/session", &params));
+        let resp: Value<Session> = try!(self.client.post("/session", &params));
         Ok(resp.value)
     }
 
     /// Navigate to the given URL
     pub fn go(&self, url: &str) -> Result<(), Error> {
         let params = GoCmd { url: url.to_string() };
-        let _: Empty = try!(self.post(&format!("/session/{}/url", &self.session_id), &params));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/url", &self.session_id), &params));
         Ok(())
     }
 
     pub fn get_current_url(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/url", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/url", self.session_id)));
         Ok(v.value)
     }
 
     pub fn back(&self) -> Result<(), Error> {
-        let _: Empty = try!(self.post(&format!("/session/{}/back", self.session_id), &Empty {}));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/back", self.session_id), &Empty {}));
         Ok(())
     }
 
     pub fn forward(&self) -> Result<(), Error> {
-        let _: Empty = try!(self.post(&format!("/session/{}/forward", self.session_id), &Empty {}));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/forward", self.session_id), &Empty {}));
         Ok(())
     }
 
     pub fn refresh(&self) -> Result<(), Error> {
-        let _: Empty = try!(self.post(&format!("/session/{}/refresh", self.session_id), &Empty {}));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/refresh", self.session_id), &Empty {}));
         Ok(())
     }
 
     pub fn get_page_source(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/source", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/source", self.session_id)));
         Ok(v.value)
     }
 
     pub fn get_title(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/title", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/title", self.session_id)));
         Ok(v.value)
     }
 
     /// Get all cookies
     pub fn get_cookies(&self) -> Result<Vec<Cookie>, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/cookie", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/cookie", self.session_id)));
         Ok(v.value)
     }
 
     pub fn get_window_handle(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/window", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/window", self.session_id)));
         Ok(v.value)
     }
 
     pub fn switch_window(&mut self, handle: &str) -> Result<(), Error> {
-        let _: Empty = try!(self.post(&format!("/session/{}/window", self.session_id), &SwitchWindowCmd::from(handle)));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/window", self.session_id), &SwitchWindowCmd::from(handle)));
         Ok(())
     }
 
     pub fn close_window(&mut self) -> Result<(), Error> {
-        let _: Empty = try!(self.delete(&format!("/session/{}/window", self.session_id)));
+        let _: Empty = try!(self.client.delete(&format!("/session/{}/window", self.session_id)));
         Ok(())
     }
 
     pub fn get_window_handles(&self) -> Result<Vec<String>, Error> {
-        let v: Value<_> = try!(self.get(&format!("/session/{}/window/handles", self.session_id)));
+        let v: Value<_> = try!(self.client.get(&format!("/session/{}/window/handles", self.session_id)));
         Ok(v.value)
     }
 
     pub fn find_element(&self, selector: &str, strategy: LocationStrategy) -> Result<Element, Error> {
         let cmd = FindElementCmd { using: strategy, value: selector};
-        let v: Value<ElementReference> = try!(self.post(&format!("/session/{}/element", self.session_id), &cmd));
+        let v: Value<ElementReference> = try!(self.client.post(&format!("/session/{}/element", self.session_id), &cmd));
         Ok(Element::new(self, v.value.reference))
     }
 
     pub fn find_elements(&self, selector: &str, strategy: LocationStrategy) -> Result<Vec<Element>, Error> {
         let cmd = FindElementCmd { using: strategy, value: selector};
-        let mut v: Value<Vec<ElementReference>> = try!(self.post(&format!("/session/{}/elements", self.session_id), &cmd));
+        let mut v: Value<Vec<ElementReference>> = try!(self.client.post(&format!("/session/{}/elements", self.session_id), &cmd));
 
         let mut elems = Vec::new();
         while let Some(er) = v.value.pop() {
@@ -297,17 +309,17 @@ impl DriverSession {
     }
 
     pub fn execute(&self, script: ExecuteCmd) -> Result<JsonValue, Error> {
-        let v: Value<JsonValue> = try!(self.post(&format!("/session/{}/execute/sync", self.session_id), &script));
+        let v: Value<JsonValue> = try!(self.client.post(&format!("/session/{}/execute/sync", self.session_id), &script));
         Ok(v.value)
     }
 
     pub fn execute_async(&self, script: ExecuteCmd) -> Result<JsonValue, Error> {
-        let v: Value<JsonValue> = try!(self.post(&format!("/session/{}/execute/async", self.session_id), &script));
+        let v: Value<JsonValue> = try!(self.client.post(&format!("/session/{}/execute/async", self.session_id), &script));
         Ok(v.value)
     }
 
     pub fn switch_to_frame(&self, handle: JsonValue) -> Result<(), Error> {
-        let _: Empty = try!(self.post(&format!("/session/{}/frame", self.session_id), &SwitchFrameCmd::from(handle)));
+        let _: Empty = try!(self.client.post(&format!("/session/{}/frame", self.session_id), &SwitchFrameCmd::from(handle)));
         Ok(())
     }
 }
@@ -315,7 +327,7 @@ impl DriverSession {
 impl Drop for DriverSession {
     fn drop(&mut self) {
         if self.drop_session {
-            let _: Result<Empty,_> = self.delete(&format!("/session/{}", self.session_id));
+            let _: Result<Empty,_> = self.client.delete(&format!("/session/{}", self.session_id));
         }
     }
 }
@@ -331,28 +343,28 @@ impl<'a> Element<'a> {
     }
 
     pub fn attribute(&self, name: &str) -> Result<String, Error> {
-        let v: Value<_> = try!(self.session.get(&format!("/session/{}/element/{}/attribute/{}", self.session.session_id(), self.reference, name)));
+        let v: Value<_> = try!(self.session.client.get(&format!("/session/{}/element/{}/attribute/{}", self.session.session_id(), self.reference, name)));
         Ok(v.value)
     }
 
 //    pub fn property(&self, name: &str) -> Result<String, Error> {
-//        let v: Value<_> = try!(self.get(&format!("/session/{}/element/{}/property/{}", self.session_id, el.reference, name)));
+//        let v: Value<_> = try!(self.client.get(&format!("/session/{}/element/{}/property/{}", self.session_id, el.reference, name)));
 //        Ok(v.value)
 //    }
 
     pub fn css_value(&self, name: &str) -> Result<String, Error> {
-        let v: Value<_> = try!(self.session.get(&format!("/session/{}/element/{}/css/{}", self.session.session_id(), self.reference, name)));
+        let v: Value<_> = try!(self.session.client.get(&format!("/session/{}/element/{}/css/{}", self.session.session_id(), self.reference, name)));
         Ok(v.value)
     }
 
     pub fn text(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.session.get(&format!("/session/{}/element/{}/text", self.session.session_id(), self.reference)));
+        let v: Value<_> = try!(self.session.client.get(&format!("/session/{}/element/{}/text", self.session.session_id(), self.reference)));
         Ok(v.value)
     }
 
     /// Returns the tag name for this element
     pub fn name(&self) -> Result<String, Error> {
-        let v: Value<_> = try!(self.session.get(&format!("/session/{}/element/{}/name", self.session.session_id(), self.reference)));
+        let v: Value<_> = try!(self.session.client.get(&format!("/session/{}/element/{}/name", self.session.session_id(), self.reference)));
         Ok(v.value)
     }
 


### PR DESCRIPTION
If we try to create a session and fail, in `DriverSession::create_session()` Drop will cause an unnecessary call to to delete the same session. In practice the api should not allow creating a DriverSession with an invalid session id.

A slightly more subtle case, which I did not cover yet, is `DriverSession::attach()`.