### PR TITLE
Support for other browsers

### DIFF
--- a/src/bin/www.rs
+++ b/src/bin/www.rs
@@ -2,6 +2,7 @@ extern crate webdriver_client;
 use webdriver_client::*;
 use webdriver_client::messages::{LocationStrategy, ExecuteCmd};
 use webdriver_client::firefox::GeckoDriver;
+use webdriver_client::chrome::ChromeDriver;
 
 extern crate rustyline;
 use rustyline::error::ReadlineError;
@@ -61,6 +62,12 @@ fn main() {
              .help("Attach to a running webdriver")
              .value_name("URL")
              .takes_value(true))
+        .arg(Arg::with_name("driver")
+             .short("D")
+             .long("driver")
+             .possible_values(&["geckodriver", "chromedriver"])
+             .default_value("geckodriver")
+             .takes_value(true))
         .arg(Arg::with_name("verbose")
              .short("v")
              .multiple(true)
@@ -79,10 +86,24 @@ fn main() {
             .build().unwrap()
             .session()
             .expect("Unable to attach to WebDriver session"),
-        None => GeckoDriver::spawn()
-            .expect("Unable to start geckodriver")
-            .session()
-            .expect("Unable to start Geckodriver session"),
+        None => match matches.value_of("driver").unwrap() {
+            "geckodriver" => {
+                GeckoDriver::spawn()
+                    .expect("Unable to start geckodriver")
+                    .session()
+                    .expect("Unable to start Geckodriver session")
+            }
+            "chromedriver" => {
+                ChromeDriver::spawn()
+                    .expect("Unable to start chromedriver")
+                    .session()
+                    .expect("Unable to start chromedriver session")
+            }
+            unsupported => {
+                // should be unreachable see Arg::possible_values()
+                panic!("Unsupported driver: {}", unsupported);
+            }
+        }
     };
 
     let mut rl = Editor::<()>::new();

--- a/src/bin/www.rs
+++ b/src/bin/www.rs
@@ -30,6 +30,11 @@ fn execute_function(name: &str, args: &str, sess: &DriverSession) -> Result<(), 
                 println!("#{} {}", idx, elem.outer_html()?);
             }
         }
+        "frames" => {
+            for (idx, elem) in sess.find_elements("iframe", LocationStrategy::Css)?.iter().enumerate() {
+                println!("#{} {}", idx, elem.raw_reference());
+            }
+        }
         "windows" => {
             for (idx, handle) in sess.get_window_handles()?.iter().enumerate() {
                 println!("#{} {}", idx, handle)
@@ -43,6 +48,14 @@ fn execute_function(name: &str, args: &str, sess: &DriverSession) -> Result<(), 
             match sess.execute(script)? {
                 JsonValue::String(ref s) => println!("{}", s),
                 other => println!("{}", other),
+            }
+        }
+        "switchframe" => {
+            let arg = args.trim();
+            if arg.is_empty() {
+                try!(sess.switch_to_frame(JsonValue::Null));
+            } else {
+                try!(sess.switch_to_frame(try!(Element::new(sess, arg.to_string()).reference())));
             }
         }
         _ => println!("Unknown function: \"{}\"", name),

--- a/src/bin/www.rs
+++ b/src/bin/www.rs
@@ -10,6 +10,8 @@ use rustyline::Editor;
 extern crate clap;
 use clap::{App, Arg};
 
+extern crate stderrlog;
+
 fn execute_function(name: &str, args: &str, sess: &DriverSession) -> Result<(), Error> {
     match name {
         "back" => try!(sess.back()),
@@ -59,7 +61,17 @@ fn main() {
              .help("Attach to a running webdriver")
              .value_name("URL")
              .takes_value(true))
+        .arg(Arg::with_name("verbose")
+             .short("v")
+             .multiple(true)
+             .help("Increases verbose"))
         .get_matches();
+
+    stderrlog::new()
+        .module("webdriver_client")
+        .verbosity(matches.occurrences_of("verbose") as usize)
+        .init()
+        .expect("Unable to initialize logging in stderr");
 
     let sess = match matches.value_of("attach-to") {
         Some(url) => HttpDriverBuilder::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@ pub mod messages;
 use messages::*;
 pub use messages::LocationStrategy;
 
+mod util;
 pub mod firefox;
+pub mod chrome;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,11 @@ impl DriverSession {
         let _: Empty = try!(self.client.post(&format!("/session/{}/frame", self.session_id), &SwitchFrameCmd::from(handle)));
         Ok(())
     }
+
+    pub fn switch_to_parent_frame(&self) -> Result<(), Error> {
+        let _: Empty = try!(self.client.post(&format!("/session/{}/frame/parent", self.session_id), &Empty {}));
+        Ok(())
+    }
 }
 
 impl Drop for DriverSession {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,8 @@ impl DriverSession {
         Ok(v.value)
     }
 
+    /// Valid values are element references as returned by Element::reference() or null to switch
+    /// to the top level frame
     pub fn switch_to_frame(&self, handle: JsonValue) -> Result<(), Error> {
         let _: Empty = try!(self.client.post(&format!("/session/{}/frame", self.session_id), &SwitchFrameCmd::from(handle)));
         Ok(())
@@ -341,7 +343,7 @@ pub struct Element<'a> {
 }
 
 impl<'a> Element<'a> {
-    fn new(s: &'a DriverSession, reference: String) -> Self {
+    pub fn new(s: &'a DriverSession, reference: String) -> Self {
         Element { session: s, reference: reference }
     }
 
@@ -384,10 +386,15 @@ impl<'a> Element<'a> {
         Ok(v.value.into_iter().map(|er| Element::new(self.session, er.reference)).collect())
     }
 
+    /// Returns a reference that can be passed on to the API
     pub fn reference(&self) -> Result<JsonValue, Error> {
         serde_json::to_value(&ElementReference::from_str(&self.reference))
             .map_err(|err| Error::from(err))
     }
+
+    /// The raw reference id that identifies this element, this can be used
+    /// with Element::new()
+    pub fn raw_reference(&self) -> &str { &self.reference }
 
     /// Gets the `innerHTML` javascript attribute for this element. Some drivers can get
     /// this using regular attributes, in others it does not work. This method gets it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate serde;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
+#[macro_use]
 extern crate serde_json;
 pub use serde_json::Value as JsonValue;
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,6 +5,7 @@ use serde::de::{Visitor, MapAccess};
 use serde::de::Error as DeError;
 use serde::ser::SerializeStruct;
 use serde_json::Value as JsonValue;
+use serde_json::map::Map;
 use std::fmt;
 
 #[derive(Debug)]
@@ -35,13 +36,15 @@ pub struct WebDriverError {
 
 #[derive(Serialize)]
 pub struct NewSessionCmd {
-    required: JsonValue,
+    capabilities: JsonValue,
+    desiredCapabilities: JsonValue,
 }
 
 impl NewSessionCmd {
     pub fn new() -> Self {
         NewSessionCmd {
-            required: JsonValue::Null,
+            capabilities: JsonValue::Object(Map::new()),
+            desiredCapabilities: JsonValue::Object(Map::new()),
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,7 +5,6 @@ use serde::de::{Visitor, MapAccess};
 use serde::de::Error as DeError;
 use serde::ser::SerializeStruct;
 use serde_json::Value as JsonValue;
-use serde_json::map::Map;
 use std::fmt;
 
 #[derive(Debug)]
@@ -37,7 +36,6 @@ pub struct WebDriverError {
 #[derive(Serialize)]
 pub struct NewSessionCmd {
     capabilities: JsonValue,
-    desiredCapabilities: JsonValue,
 }
 
 impl NewSessionCmd {
@@ -51,7 +49,6 @@ impl NewSessionCmd {
                     }
                 }
             }),
-            desiredCapabilities: JsonValue::Object(Map::new()),
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -43,7 +43,14 @@ pub struct NewSessionCmd {
 impl NewSessionCmd {
     pub fn new() -> Self {
         NewSessionCmd {
-            capabilities: JsonValue::Object(Map::new()),
+            capabilities: json!({
+                "alwaysMatch": {
+                    // ask chrome to be w3c compliant
+                    "goog:chromeOptions": {
+                        "w3c": true
+                    }
+                }
+            }),
             desiredCapabilities: JsonValue::Object(Map::new()),
         }
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -124,6 +124,8 @@ impl Serialize for ElementReference {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         let mut ss = s.serialize_struct("ElementReference", 1)?;
         ss.serialize_field("element-6066-11e4-a52e-4f735466cecf", &self.reference)?;
+        // even in w3c compliance mode chromedriver only accepts a reference name ELEMENT
+        ss.serialize_field("ELEMENT", &self.reference)?;
         ss.end()
     }
 }
@@ -203,18 +205,4 @@ pub struct Cookie {
 pub struct ExecuteCmd {
     pub script: String,
     pub args: Vec<JsonValue>,
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::{from_str, to_string};
-    use super::*;
-
-    #[test]
-    fn element_ref_serialize() {
-        let r: ElementReference = from_str("{\"element-6066-11e4-a52e-4f735466cecf\": \"ZZZZ\"}").unwrap();
-        assert_eq!(r.reference, "ZZZZ");
-        let r2 = from_str(&to_string(&r).unwrap()).unwrap();
-        assert_eq!(r, r2);
-    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,15 @@
+
+use std::io;
+use std::net::TcpListener;
+
+/// Find a TCP port number to use. This is racy but see
+/// https://bugzilla.mozilla.org/show_bug.cgi?id=1240830
+///
+/// If port is Some, check if we can bind to the given port. Otherwise
+/// pick a random port.
+pub fn check_tcp_port(port: Option<u16>) -> io::Result<u16> {
+    TcpListener::bind(&("localhost", port.unwrap_or(0)))
+        .and_then(|stream| stream.local_addr())
+        .map(|x| x.port())
+}
+

--- a/tests/webdriver_client_integration.rs
+++ b/tests/webdriver_client_integration.rs
@@ -254,7 +254,33 @@ fn execute_async() {
 
 // TODO: Test window handles
 
-// TODO: Test Frames
+#[test]
+fn test_frame_switch() {
+    let (server, sess) = setup();
+    let page1 = server.url("/page3.html");
+    sess.go(&page1).expect("Error going to page1");
+
+    // switching to parent from parent is harmless
+    sess.switch_to_parent_frame().unwrap();
+
+    let frames = sess.find_elements("iframe", LocationStrategy::Css).unwrap();
+    assert_eq!(frames.len(), 1);
+
+    sess.switch_to_frame(frames[0].reference().unwrap()).unwrap();
+    let frames = sess.find_elements("iframe", LocationStrategy::Css).unwrap();
+    assert_eq!(frames.len(), 2);
+
+    for f in &frames {
+        sess.switch_to_frame(f.reference().unwrap()).unwrap();
+        let childframes = sess.find_elements("iframe", LocationStrategy::Css).unwrap();
+        assert_eq!(childframes.len(), 0);
+        sess.switch_to_parent_frame().unwrap();
+    }
+
+    sess.switch_to_parent_frame().unwrap();
+    let frames = sess.find_elements("iframe", LocationStrategy::Css).unwrap();
+    assert_eq!(frames.len(), 1);
+}
 
 #[test]
 fn test_http_driver() {

--- a/tests/www/inner_frame.html
+++ b/tests/www/inner_frame.html
@@ -1,0 +1,5 @@
+<iframe>
+</iframe>
+
+<iframe>
+</iframe>

--- a/tests/www/page3.html
+++ b/tests/www/page3.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test page title</title>
+  </head>
+  <body>
+	  <iframe src="inner_frame.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
Hi, I've been looking into using this with other browsers

- some implementations (webdriver, chrome) will not create a session if the client sends a null in the capabilities attribute
- Added the necessary types for the chrome driver
- By default chromedriver is not compatible with the w3c webdriver spec - but one can enable compatibility with a capability extension field
- I've added a commit for a verbose flag to `www` just because it makes debugging easier

I also tried to test with other implementations, but failed for unrelated reasons

- operadriver, should to be based on chromedriver, but it did not work for me because of [this issue upstream](https://github.com/operasoftware/operachromiumdriver/issues/9)
- the webkitgtk driver crashed on me

Other than that I've added tests using the chrome driver, but it took some fiddling with travis likely because of [this issue in travis](https://github.com/travis-ci/travis-ci/issues/7150)


