### PR TITLE
Limit to one test thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
   - export PATH=$PATH:$HOME/.cargo/bin:$PWD/bin
   - which geckodriver
 script:
-  - RUST_LOG="webdriver=trace" cargo test --verbose
+  - RUST_LOG="webdriver=trace" cargo test --verbose -- --test-threads=1


### PR DESCRIPTION
Tests are flaky on travis without this, possiby because launching
multiple firefoxes in parallel exhausts system resources.

Fixes https://github.com/fluffysquirrels/webdriver_client_rust/issues/12