### PR TITLE
add possibility for custom driver paths and add `default()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rust:
   - stable
   - beta
   - nightly
+env: 
+  - RUST_BACKTRACE=1
 addons:
   # Force the latest firefox, otherwise we get an old ESR version
   # that we don't even support

--- a/src/chrome.rs
+++ b/src/chrome.rs
@@ -5,17 +5,20 @@ use super::*;
 use std::process::{Command, Child, Stdio};
 use std::thread;
 use std::time::Duration;
+use std::ffi::OsString;
 
 use super::util;
 
 pub struct ChromeDriverBuilder {
+    driver_binary: OsString,
     port: Option<u16>,
     kill_on_drop: bool,
 }
 
 impl ChromeDriverBuilder {
-    pub fn new() -> Self {
+    pub fn new<S: Into<OsString>>(path: S) -> Self {
         ChromeDriverBuilder {
+            driver_binary: path.into(),
             port: None,
             kill_on_drop: true,
         }
@@ -31,7 +34,7 @@ impl ChromeDriverBuilder {
     pub fn spawn(self) -> Result<ChromeDriver, Error> {
         let port = util::check_tcp_port(self.port)?;
 
-        let child = Command::new("chromedriver")
+        let child = Command::new(self.driver_binary)
             .arg(format!("--port={}", port))
             .stdin(Stdio::null())
             .stderr(Stdio::null())
@@ -48,6 +51,13 @@ impl ChromeDriverBuilder {
     }
 }
 
+/// The `default()` driver expects `chromedriver` in your `$PATH`
+impl Default for ChromeDriverBuilder {
+    fn default() -> Self {
+        Self::new("chromedriver")
+    }
+}
+
 /// A chromedriver process
 pub struct ChromeDriver {
     child: Child,
@@ -57,10 +67,10 @@ pub struct ChromeDriver {
 
 impl ChromeDriver {
     pub fn spawn() -> Result<Self, Error> {
-        ChromeDriverBuilder::new().spawn()
+        ChromeDriverBuilder::default().spawn()
     }
     pub fn build() -> ChromeDriverBuilder {
-        ChromeDriverBuilder::new()
+        ChromeDriverBuilder::default()
     }
 }
 

--- a/src/chrome.rs
+++ b/src/chrome.rs
@@ -16,12 +16,16 @@ pub struct ChromeDriverBuilder {
 }
 
 impl ChromeDriverBuilder {
-    pub fn new<S: Into<OsString>>(path: S) -> Self {
+    pub fn new() -> Self {
         ChromeDriverBuilder {
-            driver_binary: path.into(),
+            driver_binary: "chromedriver".into(),
             port: None,
             kill_on_drop: true,
         }
+    }
+    pub fn driver_path<S: Into<OsString>>(mut self, path: S) -> Self {
+        self.driver_binary = path.into();
+        self
     }
     pub fn port(mut self, port: u16) -> Self {
         self.port = Some(port);
@@ -51,12 +55,6 @@ impl ChromeDriverBuilder {
     }
 }
 
-/// The `default()` driver expects `chromedriver` in your `$PATH`
-impl Default for ChromeDriverBuilder {
-    fn default() -> Self {
-        Self::new("chromedriver")
-    }
-}
 
 /// A chromedriver process
 pub struct ChromeDriver {
@@ -67,10 +65,10 @@ pub struct ChromeDriver {
 
 impl ChromeDriver {
     pub fn spawn() -> Result<Self, Error> {
-        ChromeDriverBuilder::default().spawn()
+        ChromeDriverBuilder::new().spawn()
     }
     pub fn build() -> ChromeDriverBuilder {
-        ChromeDriverBuilder::default()
+        ChromeDriverBuilder::new()
     }
 }
 

--- a/src/firefox.rs
+++ b/src/firefox.rs
@@ -17,13 +17,17 @@ pub struct GeckoDriverBuilder {
 }
 
 impl GeckoDriverBuilder {
-    pub fn new<S: Into<OsString>>(path: S) -> Self {
+    pub fn new() -> Self {
         GeckoDriverBuilder {
-            driver_binary: path.into(),
+            driver_binary: "geckodriver".into(),
             port: None,
             ff_binary: "firefox".to_owned(),
             kill_on_drop: true,
         }
+    }
+    pub fn driver_path<S: Into<OsString>>(mut self, path: S) -> Self {
+        self.driver_binary = path.into();
+        self
     }
     pub fn port(mut self, port: u16) -> Self {
         self.port = Some(port);
@@ -61,13 +65,6 @@ impl GeckoDriverBuilder {
 }
 
 
-/// The `default()` driver requieres `geckodriver` in your `$PATH`
-impl Default for GeckoDriverBuilder {
-    fn default() -> Self {
-        Self::new("geckodriver")
-    }
-}
-
 /// A geckodriver process
 pub struct GeckoDriver {
     child: Child,
@@ -77,10 +74,10 @@ pub struct GeckoDriver {
 
 impl GeckoDriver {
     pub fn spawn() -> Result<Self, Error> {
-        GeckoDriverBuilder::default().spawn()
+        GeckoDriverBuilder::new().spawn()
     }
     pub fn build() -> GeckoDriverBuilder {
-        GeckoDriverBuilder::default()
+        GeckoDriverBuilder::new()
     }
 }
 


### PR DESCRIPTION
ff's and chrome's DriverBuilder constructor `new()` now takes the path to the driver as an argument. When using `default()` it is assumed that the driver is in `$PATH`.
With this it is not necessary to move the drivers to a systems directory or start the program with some sort of `PATH="$PATH:./"`.
 