### PR TITLE
remove unused field which prevents successful build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,6 @@ impl HttpClient {
 ///
 /// By default the session is removed on `Drop`
 pub struct DriverSession {
-    driver: Box<Driver>,
     client: HttpClient,
     session_id: String,
     drop_session: bool,
@@ -189,7 +188,6 @@ impl DriverSession {
         let sess = try!(Self::new_session(&client, params));
         info!("Session {} created", sess.sessionId);
         Ok(DriverSession {
-            driver: driver,
             client: client,
             session_id: sess.sessionId,
             drop_session: true,
@@ -199,12 +197,8 @@ impl DriverSession {
 
     /// Use an existing session
     pub fn attach(url: &str, session_id: &str) -> Result<DriverSession, Error> {
-        let driver = Box::new(HttpDriver {
-            url: url.to_owned(),
-        });
         let baseurl = try!(Url::parse(url).map_err(|_| Error::InvalidUrl));
         let mut s = DriverSession {
-            driver: driver,
             client: HttpClient::new(baseurl),
             session_id: session_id.to_owned(),
             // This starts as false to avoid triggering the deletion call in Drop


### PR DESCRIPTION
Since there's a `#[deny(warnings)]` the build fails because of a unused field in a struct.
