### PR TITLE
Make Driver require Send + Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl From<base64::DecodeError> for Error {
 }
 
 /// WebDriver server that can create a session.
-pub trait Driver {
+pub trait Driver: Send + Sync {
     /// The url used to connect to this driver
     fn url(&self) -> &str;
 


### PR DESCRIPTION
 - All of the types that currently implement `Driver` implement `Send` and `Sync`
 - Allows `Box<dyn Driver>`, and by extension `DriverSession` values, to be used across `await`s