### PR TITLE
Expose the capabilities object

### DIFF
--- a/bin/travis/before
+++ b/bin/travis/before
@@ -12,7 +12,7 @@ set -x;
 bin/download_geckodriver;
 
 # Install chromedriver
-version="92.0.4515.107" bin/download_chromedriver;
+version="108.0.5359.22" bin/download_chromedriver;
 export CHROME_BIN=/usr/bin/google-chrome-stable
 export CHROME_HEADLESS=1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,6 +407,10 @@ impl DriverSession {
                                                         self.session_id))?;
         Screenshot::from_string(v.value)
     }
+
+    pub fn capabilities(&self) -> &BTreeMap<String, JsonValue> {
+        &self.capabilities
+    }
 }
 
 impl Drop for DriverSession {


### PR DESCRIPTION
It is useful for the caller to be able to inspect capabilities object after the session starts. These often hold browser specific fields.

For example for chrome, https://chromedriver.chromium.org/capabilities, the returned capabilities include fields related to the chrome options (the docs are explicit about this).

Note: changed chromedriver version in travis since the builds were failing because chromedriver did not support the newer browser version.