### PR TITLE
Bump log to ^0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ hyper = "^0.10"
 serde = "^1.0"
 serde_json = "^1.0"
 serde_derive = "^1.0"
-log = "^0.3"
+log = "^0.4"
 rand = "^0.3"
 rustyline = { version = "^1.0", optional = true }
 stderrlog = "^0.2"
 clap = "^2.0"
 
 [dev-dependencies]
-env_logger = "^0.4"
+env_logger = "^0.11"
 
 [features]
 default = ["shell"]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,8 +5,8 @@ extern crate log;
 extern crate serde_json;
 extern crate webdriver_client;
 
-use env_logger::{LogBuilder, LogTarget};
-use log::LogLevelFilter;
+use env_logger::{Builder, Target};
+use log::LevelFilter;
 use std::io::Read;
 use std::env;
 use std::path::PathBuf;
@@ -577,15 +577,11 @@ fn ensure_logging_init() {
 }
 
 fn init_logging() {
-    let mut builder = LogBuilder::new();
-    builder.filter(None, LogLevelFilter::Info);
-    builder.target(LogTarget::Stdout);
-
-    if let Ok(ev) = env::var("RUST_LOG") {
-       builder.parse(&ev);
-    }
-
-    builder.init().unwrap();
+    let mut builder = Builder::new();
+    builder.filter(None, LevelFilter::Info);
+    builder.target(Target::Stdout);
+    builder.parse_env("RUST_LOG");
+    builder.init();
 }
 
 struct FileServer {


### PR DESCRIPTION
This patch bumps log to ^0.4, and bumps env_logger to a compatible version. Since [tracing-log](https://docs.rs/tracing-log/0.2.0/tracing_log/) and [tracing-subscriber](https://docs.rs/tracing-subscriber/0.3.18/tracing_subscriber/#optional-dependencies) link against log 0.4, programs using those can now receive logs from this library.

I got this to compile and it does what I need, but I was unable to run the integration tests.